### PR TITLE
Updated to latest dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,21 +23,22 @@
     "url": "https://github.com/lazd/grunt-domly/issues"
   },
   "engines": {
-    "node" : ">=0.10"
+    "node": ">=0.10"
   },
   "homepage": "https://github.com/lazd/grunt-domly",
   "dependencies": {
-    "domly": "^0.0.9",
-    "chalk": "^1.0.0",
+    "chalk": "^1.1.3",
+    "domly": "0.0.9",
     "nsdeclare": "^0.1.0"
   },
   "devDependencies": {
-    "grunt-contrib-jshint": "^0.11.0",
-    "grunt-contrib-nodeunit": "^0.4.1",
-    "grunt-contrib-clean": "^0.6.0",
-    "grunt-contrib-internal": "^0.4.12"
+    "grunt": "^1.0.1",
+    "grunt-contrib-clean": "^1.0.0",
+    "grunt-contrib-internal": "^1.2.1",
+    "grunt-contrib-jshint": "^1.0.0",
+    "grunt-contrib-nodeunit": "^1.0.0"
   },
   "peerDependencies": {
-    "grunt": "^0.4.5"
+    "grunt": ">=0.4.0"
   }
 }


### PR DESCRIPTION
Fixes #4

See http://gruntjs.com/upgrading-from-0.4-to-1.0#peer-dependencies
